### PR TITLE
build: add spiffs storage build dependency, fix cmake include for Win…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,6 @@ add_custom_target(copy-files-backup ALL DEPENDS ${CMAKE_SOURCE_DIR}/spiffs_image
         ${CMAKE_BINARY_DIR}/spiffs_image/dbup
         )
 
-spiffs_create_partition_image(storage ${CMAKE_BINARY_DIR}/spiffs_image FLASH_IN_PROJECT)
+spiffs_create_partition_image(storage ${CMAKE_BINARY_DIR}/spiffs_image FLASH_IN_PROJECT DEPENDS copy-files copy-files-backup)
 
 

--- a/components/network/CMakeLists.txt
+++ b/components/network/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS network.cpp
-        INCLUDE_DIRS . $ENV{IDF_PATH}/examples/common_components/protocol_examples_common/include
+        INCLUDE_DIRS .
         PRIV_REQUIRES nvs_flash mdns esp_netif)
 


### PR DESCRIPTION
Here you can find suggested correction for issue with spiffsgen https://github.com/espressif/esp-idf/issues/6429
The fix in main CMakeLists.txt contains dependency on targets which performs copy. Without the dependency it might happen that files are not copied before spiffs_create partition is invoked or it could be invoked when files are just partially copied.
This can be simulated just by running Windows build on slow single core computer.

The correction in components/network/CMakeLists.txt remove unnecessary include which causes problem when building on Windows, because of incorrectly escaped backslash in the path. Since the include is not necessary it can be removed.