### PR TITLE
Random delay for station connection in multimodule setups

### DIFF
--- a/components/network/network.cpp
+++ b/components/network/network.cpp
@@ -70,6 +70,8 @@ void Network::wifi_init_sta(void) {
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    // Add random connection delay up to 5 seconds for multimodule setups
+    vTaskDelay(esp_random() / (UINT32_MAX/500));
     ESP_ERROR_CHECK(esp_wifi_start());
 
     ESP_LOGI(TAG, "wifi_init_sta finished.");


### PR DESCRIPTION
This change adds initial random delay, up to 5 seconds, before station connection attempt. This fixes connection issues with some WiFi routers in case where multiple modules tries to connect at the same time during rack power up.