### PR TITLE
Add devcontainers support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:bullseye-slim
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ARG CONTAINER_USER=esp
+ARG CONTAINER_GROUP=esp
+ARG ESP_BOARD=esp32
+ARG ESP_IDF_VERSION=release/v4.1
+RUN apt-get update \
+    && apt-get install -y git curl wget flex bison gperf python3 python3-pip \
+    python3-setuptools ninja-build ccache libffi-dev libssl-dev dfu-util \
+    libusb-1.0-0 \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+RUN adduser --disabled-password --gecos "" ${CONTAINER_USER}
+USER ${CONTAINER_USER}
+ENV USER=${CONTAINER_USER}
+WORKDIR /home/${CONTAINER_USER}
+RUN mkdir -p .espressif/frameworks/ \
+    && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \
+    --recursive https://github.com/espressif/esp-idf.git \
+    .espressif/frameworks/esp-idf \
+    && python3 .espressif/frameworks/esp-idf/tools/idf_tools.py install cmake \
+    && .espressif/frameworks/esp-idf/install.sh ${ESP_BOARD}
+ENV IDF_TOOLS_PATH=/home/${CONTAINER_USER}/.espressif
+RUN echo "source /home/${CONTAINER_USER}/.espressif/frameworks/esp-idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
+CMD "/bin/bash"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG=C.UTF-8
 ARG CONTAINER_USER=esp
 ARG CONTAINER_GROUP=esp
 ARG ESP_BOARD=esp32
-ARG ESP_IDF_VERSION=release/v4.1
+ARG ESP_IDF_VERSION=release/v4.4
 RUN apt-get update \
     && apt-get install -y git curl wget flex bison gperf python3 python3-pip \
     python3-setuptools ninja-build ccache libffi-dev libssl-dev dfu-util \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,13 @@
 {
   "name": "esp-idf",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      "ESP_BOARD": "esp32",
-      "ESP_IDF_VERSION": "release/v4.1"
-    }
-  },
+  "image": "docker.io/sergiogasquez/esp-idf-env:v4.4_esp32",
+  // "build": {
+  //   "dockerfile": "Dockerfile",
+  //   "args": {
+  //     "ESP_BOARD": "esp32",
+  //     "ESP_IDF_VERSION": "release/v4.4"
+  //   }
+  // },
   "settings": {
     "editor.formatOnPaste": true,
     "editor.formatOnSave": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "esp-idf",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "ESP_BOARD": "esp32",
+      "ESP_IDF_VERSION": "release/v4.1"
+    }
+  },
+  "settings": {
+    "editor.formatOnPaste": true,
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "modifications",
+    "editor.formatOnType": true,
+    "lldb.executable": "/usr/bin/lldb",
+    "files.watcherExclude": {
+      "**/target/**": true
+    }
+  },
+  "extensions": [
+    "mutantdino.resourcemonitor",
+    "yzhang.markdown-all-in-one",
+    "espressif.esp-idf-extension"
+  ],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/esp/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/home/esp/workspace/"
+}

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,19 @@
+FROM gitpod/workspace-base
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ARG CONTAINER_USER=gitpod
+ARG CONTAINER_GROUP=gitpod
+ARG ESP_BOARD=esp32
+ARG ESP_IDF_VERSION=release/v4.1
+RUN sudo install-packages -y git curl wget flex bison gperf python3 python3-pip \
+    python3-setuptools ninja-build ccache libffi-dev libssl-dev dfu-util \
+    libusb-1.0-0
+USER ${CONTAINER_USER}
+WORKDIR /home/${CONTAINER_USER}
+RUN mkdir -p .espressif/frameworks/ \
+    && git clone --branch ${ESP_IDF_VERSION} --depth 1 --shallow-submodules \
+    --recursive https://github.com/espressif/esp-idf.git \
+    .espressif/frameworks/esp-idf \
+    && python3 .espressif/frameworks/esp-idf/tools/idf_tools.py install cmake \
+    && .espressif/frameworks/esp-idf/install.sh ${ESP_BOARD}
+ENV IDF_TOOLS_PATH=/home/${CONTAINER_USER}/.espressif

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -4,7 +4,7 @@ ENV LANG=C.UTF-8
 ARG CONTAINER_USER=gitpod
 ARG CONTAINER_GROUP=gitpod
 ARG ESP_BOARD=esp32
-ARG ESP_IDF_VERSION=release/v4.1
+ARG ESP_IDF_VERSION=release/v4.4
 RUN sudo install-packages -y git curl wget flex bison gperf python3 python3-pip \
     python3-setuptools ninja-build ccache libffi-dev libssl-dev dfu-util \
     libusb-1.0-0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+ - name: Setup environment variables for ESP-IDF
+   command: |
+     source /home/gitpod/.espressif/frameworks/esp-idf/export.sh > /dev/null 2>&1
+vscode:
+  extensions:
+    - espressif.esp-idf-extension
+    - anwar.resourcemonitor
+    - yzhang.markdown-all-in-one

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,8 @@ Open the repository folder with Visual Studio Code and open the container, there
 - Open the Command Palette and select `Remote-Containers: Reopen in Container`
 - Use the open in a remote window button on the bottom left corner to `Reopen in Container`
 
+By default, the image will be pulled from [esp-idf-env](https://hub.docker.com/r/sergiogasquez/esp-idf-env), but users can also build
+it from the Dockerfile by editing the [`.devcontainer.json`](https://github.com/ctag-fh-kiel/ctag-tbd/blob/master/.devcontainer/devcontainer.json#L3-L10)
 ### tbd cloud compiler
 The [tbd cloud compiler](https://fxwiegand.github.io/tbd-cloud-compiler/) allows you to reduce the size of the ctag-tbd firmware, therefore making up more free space for your samples, by removing one or multiple plug-ins that you don't want to use with your module via a web ui. It makes use of GitHub actions running in your own forked repository and therefore doesn't depend on any toolchain installed on your own system. For more information take a look at the [user guide](https://fxwiegand.github.io/tbd-cloud-compiler/user-guide).
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 ![CTAG-TBD](tbd.png)
 
 ## Documentation (in the works):
-[Summary table](https://docs.google.com/spreadsheets/d/1dBZtuBIdtgMqoRruYX-VDdDirdTQ6RD-oz-j79q-bmQ/edit?usp=sharing) of all available plugins. 
+[Summary table](https://docs.google.com/spreadsheets/d/1dBZtuBIdtgMqoRruYX-VDdDirdTQ6RD-oz-j79q-bmQ/edit?usp=sharing) of all available plugins.
 Documentation on TBD usage can be found [here (Google Docs)](https://docs.google.com/document/d/1c8mjxWjdiJNP0xpkU2CxRUp9av6V4W39wARJf3_SMSo/edit?usp=sharing)
 Tutorial videos in [YouTube playlist](https://www.youtube.com/playlist?list=PLB5iCbhcvJ2qdD7s1o9wsvQ9qtsCUWVLR)
 
@@ -29,7 +29,7 @@ In order to use the sample rom, you can upload from the edit sample rom page [fa
 - Because we can.
 - To fight boredom and despair of Corona Virus!
 
-## Features: 
+## Features:
 - More than 30 high quality audio generators and effects.
 - Easy DSP plugin development.
 - **NEW!!!** Sample ROM playback and wavetable oscillator with user wavetables from sample ROM [details here](sample_rom/readme.md)
@@ -61,7 +61,7 @@ In order to use the sample rom, you can upload from the edit sample rom page [fa
 **NEW!!!** You can build custom firmwares with plugin subsets and to increase sample-rom using the [cloud compiler](https://fxwiegand.github.io/tbd-cloud-compiler/).
 No need for a toolchain on your own system.
 
-For developing your own plugins / make TBD yours, you need C/C++ skills. 
+For developing your own plugins / make TBD yours, you need C/C++ skills.
 You may want to check the [TBD simulator](simulator/readme.md) for easy plugin development without TBD hardware.
 
 You can build the firmware using a Github action. Just fork the ctag-tbd repo to your Github account and enable the supplied
@@ -83,12 +83,33 @@ cd ctag-tbd
 git submodule update --init --recursive
 idf.py build
 ```
+### Devcontainers
+Devcontainers allow users to develop in an isolated container, with all the
+dependencies installed and with the features of an IDE. Currently there are two
+methods supported.
+
+Currently both devcontainers are using [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4) version of [esp-idf](https://github.com/espressif/esp-idf)
+#### Gitpod
+Gitpod offers free online workspaces, just by pressing this button, you'll have
+access to a development environment for ctag-tbd in a browser tab:
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/github.com/ctag-fh-kiel/ctag-tbd)
+#### VsCode Devcontainers
+Visual Studio Code also offers [developing inside a Container](https://code.visualstudio.com/docs/remote/containers),
+but for this approach, the user will need to install:
+- [Visual Studio Code](https://code.visualstudio.com/download)
+  - [Remote - Container Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- [Docker](https://docs.docker.com/get-docker/)
+
+Open the repository folder with Visual Studio Code and open the container, there are several ways to open the container:
+- When opening Visual Studio Code, a popup will come up asking to open reopen the folder in a Container, click `Reopen in Container`
+- Open the Command Palette and select `Remote-Containers: Reopen in Container`
+- Use the open in a remote window button on the bottom left corner to `Reopen in Container`
 
 ### tbd cloud compiler
 The [tbd cloud compiler](https://fxwiegand.github.io/tbd-cloud-compiler/) allows you to reduce the size of the ctag-tbd firmware, therefore making up more free space for your samples, by removing one or multiple plug-ins that you don't want to use with your module via a web ui. It makes use of GitHub actions running in your own forked repository and therefore doesn't depend on any toolchain installed on your own system. For more information take a look at the [user guide](https://fxwiegand.github.io/tbd-cloud-compiler/user-guide).
 
 ## How to flash
-Either use the binaries available from the [releases at github](https://github.com/ctag-fh-kiel/ctag-tbd/releases) to flash through the TBD's web ui. 
+Either use the binaries available from the [releases at github](https://github.com/ctag-fh-kiel/ctag-tbd/releases) to flash through the TBD's web ui.
 
 Or use [ESP Tool](https://github.com/espressif/esptool) to flash through a USB connection with your PC (check [this script](bin/flash.sh)).
 


### PR DESCRIPTION
Allow users to develop using containers to bootstrap the development environment, currently, there are 2 devcontainers options supported:
- Gitpod
- VsCode

Currently, the [image being used for VsCode](https://github.com/SergioGasquez/ctag-tbd/blob/b6fe8f663acad60adc929d48fdb080cbf54d3724/.devcontainer/devcontainer.json#L3) is [hosted under my Dockerhub account](https://hub.docker.com/r/sergiogasquez/esp-idf-env), if you don't like this approach, we could add some CI in the repo which builds the Dockerfile and publishes the image to a ctag-tbd account

> Note that the Gitpod button won't work yet, since its points to the `ctag-fh-kiel/ctag-tbd` repo, it will only work once it's merged, in the meantime, you can use the following link: gitpod.io/#https://github.com/SergioGasquez/ctag-tbd