### PR TITLE
add new dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,26 +1,110 @@
-FROM debian:bullseye-slim
-ENV DEBIAN_FRONTEND=noninteractive
+ARG TBD_IDF_VERSION=v5.4
+
+
+#### c++ build ####
+
+FROM espressif/idf:release-${TBD_IDF_VERSION} AS esp_idf_stage
+
+# tbd specifc configs
+ENV TBD_ENV_NO_TBD_CMD=0
+ENV TBD_ENV_NO_IDF_CMD=0
+ARG TBD_PATH=/opt/tbd
+ENV TBD_IDF_PATH=/opt/esp/idf
+
+# non config vars
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-ARG CONTAINER_USER=esp
-ARG CONTAINER_GROUP=esp
-ARG ESP_BOARD=esp32
-ARG ESP_IDF_VERSION=release/v4.4
-RUN apt-get update \
-    && apt-get install -y git curl wget flex bison gperf python3 python3-pip \
-    python3-setuptools ninja-build ccache libffi-dev libssl-dev dfu-util \
-    libusb-1.0-0 \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
-RUN adduser --disabled-password --gecos "" ${CONTAINER_USER}
-USER ${CONTAINER_USER}
-ENV USER=${CONTAINER_USER}
-WORKDIR /home/${CONTAINER_USER}
-RUN mkdir -p .espressif/frameworks/ \
-    && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \
-    --recursive https://github.com/espressif/esp-idf.git \
-    .espressif/frameworks/esp-idf \
-    && python3 .espressif/frameworks/esp-idf/tools/idf_tools.py install cmake \
-    && .espressif/frameworks/esp-idf/install.sh ${ESP_BOARD}
-ENV IDF_TOOLS_PATH=/home/${CONTAINER_USER}/.espressif
-RUN echo "source /home/${CONTAINER_USER}/.espressif/frameworks/esp-idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
-CMD "/bin/bash"
+ENV TBD_IN_CONTAINER=1
+ARG TBD_IDF_ACTIVATE=$TBD_IDF_PATH/export.sh
+ARG TBD_INIT=$TBD_PATH/tbd-init.sh
+
+RUN apt-get update -y && apt-get install -y \
+    udev \
+    software-properties-common \
+    alsa-utils \
+    bash-completion \
+    pulseaudio \
+    libpixman-1-0 \
+    libsdl2-2.0-0 \
+    libslirp0 \
+    libboost-all-dev \
+    libasound2-dev \
+    libglib2.0-dev \
+    libgcrypt20-dev \
+    fish \
+    micro
+
+COPY ./tbd-init.sh "$TBD_PATH/"
+ENV PATH="$PATH:$TBD_PATH"
+RUN "$TBD_INIT" integrate-idf
+RUN "$TBD_INIT" install-clang
+
+ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+CMD ["/bin/bash", "-c"]
+
+#### tbd build tool ####
+
+# required to build TBD software
+FROM esp_idf_stage AS tbd_build_stage
+
+RUN . "$TBD_IDF_ACTIVATE" && pip install \
+    typer \
+    cxxheaderparser \
+    jinja2 \
+    GitPython \
+    loguru \
+    pyhumps \
+    pydantic \
+    pyyaml
+
+ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+CMD ["/bin/bash", "-c"]
+
+
+#### docs build tools ####
+
+FROM tbd_build_stage AS sphinx_docs_stage
+
+RUN apt-get install -y \
+    doxygen
+
+RUN . "$TBD_IDF_ACTIVATE" && pip install \
+    sphinx \
+    pydata-sphinx-theme \
+    sphinxcontrib-youtube \
+    esbonio \
+    breathe
+
+ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+CMD ["/bin/bash", "-c"]
+
+
+#### qemu for esp32 ####
+
+FROM sphinx_docs_stage AS quemu_latest_stage
+
+RUN cd /opt \
+		&& git clone --quiet https://github.com/espressif/qemu.git \
+		&& cd qemu \
+		&& mkdir -p build \
+		&& cd build \
+		&& ../configure --target-list=xtensa-softmmu --without-default-features --enable-slirp  --enable-gcrypt \
+		&& make -j $(nproc) vga=no \
+		&& make install
+
+ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+CMD ["/bin/bash", "-c"]
+
+
+#### c++ package manger  ####
+
+# required to generate TBD documentation
+#FROM quemu_latest_stage AS tbd_package_manager_stage
+#
+#ENV TBD_ENV_NO_VCPKG=0
+#ENV VCPKG_ROOT=/opt/vcpkg
+#
+#RUN "$TBD_INIT" install-vcpkg && "$TBD_INIT" integrate-vcpkg
+
+#ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+#CMD ["/bin/bash", "-c"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,28 +1,74 @@
 {
-  "name": "esp-idf",
-  "image": "docker.io/sergiogasquez/esp-idf-env:v4.4_esp32",
-  // "build": {
-  //   "dockerfile": "Dockerfile",
-  //   "args": {
-  //     "ESP_BOARD": "esp32",
-  //     "ESP_IDF_VERSION": "release/v4.4"
-  //   }
-  // },
-  "settings": {
-    "editor.formatOnPaste": true,
-    "editor.formatOnSave": true,
-    "editor.formatOnSaveMode": "modifications",
-    "editor.formatOnType": true,
-    "lldb.executable": "/usr/bin/lldb",
-    "files.watcherExclude": {
-      "**/target/**": true
-    }
-  },
-  "extensions": [
-    "mutantdino.resourcemonitor",
-    "yzhang.markdown-all-in-one",
-    "espressif.esp-idf-extension"
-  ],
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/esp/workspace,type=bind,consistency=cached",
-  "workspaceFolder": "/home/esp/workspace/"
+    "name": "tbd-dev-container",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/ctag_tbd,type=bind",
+    "workspaceFolder": "/workspaces/ctag_tbd",
+    "mounts": [
+        "source=extensionCache,target=/root/.vscode-server/extensions,type=volume",
+
+        // flashing: uncomment for device flashing
+        // warning: this is potentially dangerous
+        //
+        // "type=bind,source=/dev,target=/dev",
+
+        // sound: uncomment for desktop build sound output
+        // https://comp0016-team-24.github.io/dev/problem-solving/2020/10/30/passing-audio-into-docker.html
+        //
+        // "source=/run/user/1000/pulse/native,target=/run/user/1000/pulse/native,type=bind"
+    ],
+    "forwardPorts": [2024],
+    "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile"
+    },
+    "containerEnv": {
+        "TBD_PROJECT_DIR": "${containerWorkspaceFolder}",
+        "PYTHONPATH": "${containerWorkspaceFolder}/tools/tbd_tools",
+        "PULSE_SERVER": "unix:/run/user/1000/pulse/native"
+    },
+    "remoteEnv": {
+        // setting PATH in container causes build error
+        "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/tools/tbd_tools/bin"
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                // configure IDF plugin
+                "idf.espIdfPath": "/opt/esp/idf",
+                "idf.toolsPath": "/opt/esp",
+                "idf.gitPath": "/usr/bin/git",
+                "idf.adapterTargetName": "esp32s3",
+                "idf.buildPath": "${workspaceFolder}/build/firmware",
+                "idf.pythonBinPath": "/opt/esp/python_env/idf5.4_py3.12_env/bin/python",
+                "cmake.buildDirectory": "${workspaceFolder}/build/firmware",
+                "cmake.automaticReconfigure": false,
+                "esbonio.sphinx.buildDir": "${workspaceFolder}/build/docs",
+                "esbonio.sphinx.confDir": "${workspaceFolder}/docs/config",
+                "esbonio.sphinx.srcDir": "${workspaceFolder}/docs",
+                "python.defaultInterpreterPath": "/opt/esp/python_env/idf5.4_py3.12_env/bin/python"
+            },
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack",
+                "espressif.esp-idf-extension",
+                "ms-vscode.cpptools",
+                "ms-vscode.cpptools-extension-pack",
+                "swyddfa.esbonio",
+                "ms-python.vscode-pylance",
+                "ms-python.python",
+                "ms-python.debugpy",
+                "lextudio.restructuredtext",
+                "trond-snekvik.simple-rst",
+                "ms-vscode.cpptools-themes",
+                "twxs.cmake",
+                "samuelcolvin.jinjahtml",
+                "tamasfe.even-better-toml"
+            ]
+        }
+    },
+    "runArgs": [
+        // flashing: uncomment for device flashing
+        // warning: this is potentially dangerous
+        //
+        // "--privileged",
+    ]
 }

--- a/.devcontainer/tbd-init.sh
+++ b/.devcontainer/tbd-init.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env sh
+
+tbd_main() {
+
+is_sourced() {
+    if [ -n "$BASH_VERSION" ]; then
+        (return 0 2>/dev/null) && return 0 
+    else 
+        case ${0##*/} in sh|-sh|dash|-dash|bash) return 0;; esac
+    fi
+    return 1
+}
+
+_cleanup() {
+    trap - EXIT
+    trap - INT
+
+    if is_sourced; then
+        unset -f tbd_main
+        
+        return $1
+    else
+        exit $1
+    fi
+}
+
+_exit_on_error() {
+    _cleanup 1
+}
+trap _exit_on_error INT
+
+cleanup() {
+    _cleanup 0
+}
+trap cleanup EXIT
+
+raise() {
+    echo "ERROR: $@" >&2
+    kill -s INT $$
+}
+
+# robust check for anything boolean like
+local value
+is_true() {
+    value=`echo "$1" | awk '{print tolower($0)}'`
+    if [ -z "$value" ] || [ "$value" = "0" ] || [ "$value" = "false" ] \
+        || [ "$value" = "no" ] || [ "$value" = "n" ]
+    then
+        return 1
+    fi
+
+    if [ "$value" = "1" ] || [ "$value" = "true" ] \
+        || [ "$value" = "yes" ] || [ "$value" = "y" ]
+    then
+        return 0
+    fi
+
+    raise "$value is not a valid boolean"
+}
+
+# turn anything that looks like false into 0 and anything else into true
+format_bool() {
+    if is_true $1; then
+        echo "$1=1"
+    else
+        echo "$1=0"
+    fi
+}
+
+local command
+local verbose
+local command_args
+parse_options() {
+    while :; do
+        case $1 in 
+            -h|-\?|--help)
+                echo "tbd bootstrapping tool"
+                exit
+                ;;
+            -v|--verbose)
+                verbose=1
+                ;;
+            -?*)
+                raise "unknown command line option: $1"
+                ;;
+            *)
+                break
+        esac
+        shift
+    done
+    if [ "$#" -lt "1" ]; then
+        raise "no command provided"
+    else
+        command=$1
+        shift
+    fi
+    command_args=$@
+}
+
+local vcpkg_install_path
+find_vcpkg_path() {
+    if [ -n "$VCPKG_ROOT" ]; then
+        vcpkg_install_path="$VCPKG_ROOT"
+    elif [ -n "$1" ]; then
+        vcpkg_install_path="$1"
+    else
+        raise "no installation location for vcpkg provided"
+    fi
+}
+
+install_vcpkg() {
+    find_vcpkg_path "$1"
+    echo "installing vcpkg $vcpkg_install_path"
+
+    mkdir -p "$vcpkg_install_path"
+
+    # source https://aka.ms/vcpkg-init.sh
+    #
+    # we can not use the provided script because it requires being sourced 
+    #
+    local base_version='2024-10-18'
+    if [ $base_version != 'latest' ] \
+        && [ -f "${vcpkg_install_path}/vcpkg" ] \
+        && [ -f "${vcpkg_install_path}/vcpkg-version.txt" ] \
+        && [ "$(cat "${vcpkg_install_path}/vcpkg-version.txt")" = $base_version] 
+    then
+        return 0;
+    fi
+
+    local vcpkg_binary="$vcpkg_install_path/vcpkg"
+    if [ "$(uname)" = "Darwin" ]; then
+        curl -L -o "$vcpkg_binary" https://github.com/microsoft/vcpkg-tool/releases/download/2024-10-18/vcpkg-macos
+    elif [ -e /etc/alpine-release ]; then
+        curl -L -o "$vcpkg_binary" https://github.com/microsoft/vcpkg-tool/releases/download/2024-10-18/vcpkg-muslc
+    else
+        curl -L -o "$vcpkg_binary" https://github.com/microsoft/vcpkg-tool/releases/download/2024-10-18/vcpkg-glibc
+    fi
+
+    if [ ! -f "$vcpkg_binary" ]; then
+        raise "ERROR: Unable to find/get vcpkg binary $vcpkg_binary"
+        return 1;
+    fi
+
+    if ! chmod +x "$vcpkg_binary"; then
+        raise "failed to set run permission on vcpkg executable"
+    fi
+
+    if ! "$vcpkg_binary" bootstrap-standalone; then
+        raise "ERROR: vcpkg bootstrapping failed"
+    fi
+
+    return 0;
+}
+
+integrate_vcpkg() {
+    local bash_rc="$HOME/.bashrc"
+    find_vcpkg_path "$1"
+
+    echo "setting up integrations fro vcpkg in $vcpkg_install_path to $bash_rc"
+
+    local completions="/scripts/vcpkg_completion.bash"
+    local completions_finds=$(grep "$completions" "$bash_rc")
+    if [ -z "$completions_finds" ]; then
+        echo "installing vcpkg bash completions"
+
+        echo 'if [ -z "$TBD_ENV_NO_VCPKG" ] || [ $TBD_ENV_NO_VCPKG != "1" ]; then'  >> "$bash_rc"
+        echo "    . $vcpkg_install_path/$completions" >> "$bash_rc"
+        echo 'fi'                                     >> "$bash_rc"
+    else
+        echo "vcpkg completions already installed"
+    fi
+
+    local alias_expr="alias vcpkg="
+    local alias_finds=$(grep "$alias_expr" "$bash_rc")
+    if [ -z "$alias_finds" ]; then
+        echo "installing vcpkg executable alias"
+
+        echo 'if [ -z "$TBD_ENV_NO_VCPKG" ] || [ $TBD_ENV_NO_VCPKG != "1" ]; then' >> "$bash_rc"
+        echo "    alias vcpkg='$vcpkg_install_path/vcpkg'" >> "$bash_rc"
+        echo 'fi'                                          >> "$bash_rc"
+    else
+        echo "vcpkg alias alredy present"
+    fi
+
+    return 0;
+}
+
+install_clang() {
+  local clang_installer_dir=/opt/clang_utils
+  local clang_installer="${clang_installer_dir}/llvm.sh"
+
+  # download installer
+  if ! mkdir -p "$clang_installer_dir"; then
+  	raise "failed to create clang utils dir"
+  fi
+
+  if ! curl -o "$clang_installer" "https://apt.llvm.org/llvm.sh"; then
+	raise "failed to download clang installer"
+  fi
+
+  if ! chmod +x "$clang_installer"; then
+	raise "failed to set permissions on clang installer"
+  fi
+   
+  # install
+  if ! "$clang_installer" 18 all; then 
+	raise "clang installation failed"
+  fi
+}
+
+local idf_install_path
+find_idf_path() {
+    if [ -n "$IDF_PATH" ]; then
+        idf_install_path="$IDF_PATH"
+    elif [ -n "$1" ]; then
+        idf_install_path="$1"
+    else
+        raise "no installation location for ESP IDF provided"
+    fi
+}
+
+integrate_idf() {
+    local bash_rc="$HOME/.bashrc"
+    find_idf_path "$1"
+
+    echo "setting up integrations for ESP IDF in $idf_install_path to $bash_rc"
+
+    local idf_if='if ! is_true $TBD_ENV_NO_IDF; then'
+    local idf_finds=$(grep "$idf_if" "$bash_rc")
+    if [ -z "$idf_finds" ]; then
+        echo "installing idf integrations"
+
+        echo 'if [ -z "$TBD_ENV_NO_IDF" ] || [ $TBD_ENV_NO_IDF != "1" ]; then' >> "$bash_rc"
+        echo "    . $idf_install_path/export.sh"              >> "$bash_rc"
+        echo '    TBD_PYTHON_ENV_PATH="$IDF_PYTHON_ENV_PATH"' >> "$bash_rc"
+        echo 'fi'                                             >> "$bash_rc"
+    else
+        echo "vcpkg completions already installed"
+    fi
+
+    return 0;
+}
+
+# main
+    
+parse_options $@
+case $command in
+    integrate-idf)
+        integrate_idf $command_args
+        ;;
+    install-vcpkg)
+        install_vcpkg $command_args
+        ;;
+    integrate-vcpkg)
+        integrate_vcpkg $command_args
+        ;;
+    install-clang)
+        install_clang $command_args
+        ;;
+    *)
+        raise "unknown command $command"
+        ;;
+esac
+cleanup
+
+}
+
+tbd_main $@
+
+


### PR DESCRIPTION
# Problem

The current dev container is 
- not based on the official IDF image
- does not target the IDF 5.4 which future TBD releases will be using
- is outdated and not tested with current TBD releases
- will be completely replaced with a completely different container in the next release (Q1 2025)

Current users are only left with either trying to use the old dev container with no assurances or install IDF locally.

# Patch Contents

Replace the outdated dev container with a patch from dev, as a forwarded feature. 

# Limitations

- new TBD tools are not provided
- only guaranteed build is BBA1 & BB2
